### PR TITLE
Fix terminology: structural reuse vs expression evaluation (#39)

### DIFF
--- a/tools/etc/docs/concepts/terminology.adoc
+++ b/tools/etc/docs/concepts/terminology.adoc
@@ -5,7 +5,7 @@ When describing JSON++ behaviour, always prefer these terms over informal altern
 
 === Structural Reuse
 
-_Structural reuse_ is the umbrella concept covering all mechanisms by which a JSON++ object incorporates structure or values from another object.
+_Structural reuse_ is the umbrella concept covering all mechanisms by which a JSON++ object incorporates structure from other objects.
 JSON++ provides two structural-reuse constructs: *inheritance* (`$extends`) and *inclusion with defaults* (`$includes`).
 
 === Inheritance (`$extends`)


### PR DESCRIPTION
Fixes #39.

## Summary

- **`concepts/terminology.adoc`**: narrow the definition of _Structural Reuse_ from "incorporates structure **or values** from another object" to "incorporates structure from other objects"

## Why

The phrase "or values from another object" was ambiguous. `eval:` also produces values, so a reader could group expression evaluation under structural reuse — exactly the Meaning B the issue describes. Removing "or values" restricts the definition to the two actual structural-reuse constructs (`$extends`, `$includes`) and leaves no ambiguity.

## Diff

```diff
- _Structural reuse_ is the umbrella concept covering all mechanisms by which a JSON++ object incorporates structure or values from another object.
+ _Structural reuse_ is the umbrella concept covering all mechanisms by which a JSON++ object incorporates structure from other objects.
```

## Scope

All other occurrences of "structural reuse" in the docs already correctly treat it as separate from expression evaluation — no further changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)