### PR TITLE
docs: introduce structural composition as explicit sub-category of structural reuse

### DIFF
--- a/tools/etc/docs/concepts/design-principles.adoc
+++ b/tools/etc/docs/concepts/design-principles.adoc
@@ -27,6 +27,7 @@ This also implies that the same extension concept naturally applies to other JSO
 === Principle 3 — Declarative Structural Reuse
 
 JSON{plus}{plus} introduces explicit constructs for expressing structural reuse.
-Configurations can extend other configurations and override selected fields.
-This mechanism enables developers to describe relationships between configurations directly in the data structure rather than through external tooling.
+
+* *Structural composition* constructs (`$extends`, `$includes`) let configurations combine documents directly, describing relationships in the data structure itself rather than through external tooling.
+* *Expression evaluation* (`eval:`) lets configurations compute values dynamically from the composed result.
 

--- a/tools/etc/docs/concepts/overview.adoc
+++ b/tools/etc/docs/concepts/overview.adoc
@@ -1,6 +1,6 @@
 == jq++: JSON with structural reuse and expression evaluation
 
-https://github.com/dakusui/jqplusplus[jq++] is a tool that extends your JSON with file- and node-level structural reuse (via `$extends` and `$includes`) and expression evaluation (via `eval:`).
+https://github.com/dakusui/jqplusplus[jq++] is a tool that extends your JSON with *structural reuse*: structural composition (via `$extends` and `$includes`) and expression evaluation (via `eval:`).
 It productizes the ideas of https://github.com/dakusui/jq-front[ jq-front], which was named after *Cfront*<<Cfront>>—the classic {cpp}-to-C translator—and gives JSON a similar “front-end” power.
 
 Despite criticism of JSON<<json>> as a format for configuration<<cr>>, JSON has clear strengths: broad tool support, a good balance between machine and human readability, and simple, unambiguous syntax.
@@ -132,7 +132,7 @@ With `greeting.json` as `{"greeting":"Hello"}` and `name.json` as `{"yourname":"
 === YAML?
 
 JSON is often criticized as a configuration language<<cr>>.
-Whether or not you agree, jq++ can still improve a YAML-based workflow: you keep YAML for editing, then convert to JSON, run jq++ for structural reuse and expression evaluation, and optionally convert back to YAML.
+Whether or not you agree, jq{plus}{plus} can still improve a YAML-based workflow: you keep YAML for editing, then convert to JSON, run jq{plus}{plus} for structural reuse, and optionally convert back to YAML.
 
 [cols="1a,1a"]
 |===
@@ -183,7 +183,7 @@ $ yq . -j in.yaml | jq++ | yq . -y
 
 // suppress inspection "SpellCheckingInspection"
 HOCON<<hocon>> is another human-friendly format with inheritance and references.
-You might still prefer jq++:
+You might still prefer jq{plus}{plus}:
 
 - **Standard JSON in and out.** jq++ reads and writes JSON, which fits into almost any toolchain.
 - **Custom behavior via expression evaluation.** You can define how values are computed using `eval:` expressions without leaving JSON.

--- a/tools/etc/docs/concepts/terminology.adoc
+++ b/tools/etc/docs/concepts/terminology.adoc
@@ -5,8 +5,26 @@ When describing JSON++ behaviour, always prefer these terms over informal altern
 
 === Structural Reuse
 
-_Structural reuse_ is the umbrella concept covering all mechanisms by which a JSON++ object incorporates structure from other objects.
-JSON++ provides two structural-reuse constructs: *inheritance* (`$extends`) and *inclusion with defaults* (`$includes`).
+JSON{plus}{plus} provides *structural reuse* mechanisms that allow configurations to be constructed from reusable fragments.
+Structural reuse consists of two categories:
+
+* *Structural composition*, which combines configuration documents:
+** *Inheritance* (`$extends`)
+** *Inclusion* (`$includes`)
+* *Expression evaluation* (`eval:`), which computes configuration values dynamically.
+
+----
+Structural reuse
+ ├─ structural composition
+ │   ├─ inheritance ($extends)
+ │   └─ inclusion ($includes)
+ └─ expression evaluation (eval:)
+----
+
+=== Structural Composition
+
+_Structural composition_ is the subset of structural reuse that combines configuration documents structurally.
+JSON++ provides two structural-composition constructs: *inheritance* (`$extends`) and *inclusion with defaults* (`$includes`).
 
 === Inheritance (`$extends`)
 
@@ -55,7 +73,7 @@ The full priority order from highest to lowest is:
 === Expression Evaluation (`eval:`)
 
 *Expression evaluation* is the mechanism by which string values or keys prefixed with `eval:` are replaced by the result of evaluating the suffix as a jq expression.
-The expression is evaluated against the current JSON root after all structural reuse has been resolved.
+The expression is evaluated against the current JSON root after all structural composition has been resolved.
 
 [source,json]
 ----

--- a/tools/etc/docs/manual/structural-reuse.adoc
+++ b/tools/etc/docs/manual/structural-reuse.adoc
@@ -1,7 +1,9 @@
 == Structural Reuse
 
-JSON++ provides two constructs for reusing structure across configurations: *inheritance* (`$extends`) and *inclusion with defaults* (`$includes`).
-Together they are referred to as _structural reuse_.
+JSON{plus}{plus} provides *structural reuse* mechanisms that allow configurations to be constructed from reusable fragments.
+Structural reuse consists of *structural composition* (`$extends` and `$includes`) and *expression evaluation* (`eval:`).
+
+This page focuses on *structural composition*: the two constructs that combine configuration documents — *inheritance* (`$extends`) and *inclusion with defaults* (`$includes`).
 
 For precise definitions and precedence rules see the link:../concepts/terminology.html[Terminology] page.
 For the full syntax of each construct see the link:../reference/syntax-reference.html[Syntax Reference].

--- a/tools/etc/docs/reference/syntax-reference.adoc
+++ b/tools/etc/docs/reference/syntax-reference.adoc
@@ -1,8 +1,16 @@
 == JSON++ Syntax Reference
 
-JSON++ is a lightweight extension of JSON that adds three mechanisms to standard JSON: **structural reuse** for reusing configuration structures (via inheritance and inclusion with defaults), **expression evaluation** for computing values dynamically, and **local node definitions** for in-file reuse.
-All JSON++ annotations are valid JSON, so existing JSON tooling continues to work on JSON++ files.
-The `jq++` tool evaluates a JSON++ file and emits ordinary JSON.
+JSON{plus}{plus} is a lightweight extension of JSON that adds three mechanisms to standard JSON:
+
+* **structural composition** for combining configuration documents (via inheritance with `$extends` and inclusion with `$includes`),
+* **expression evaluation** for computing values dynamically (via `eval:`),
+and
+* **local node definitions** for in-file reuse.
+
+Structural composition and expression evaluation together form *structural reuse* — the full set of mechanisms for constructing configurations from reusable parts.
+
+All JSON{plus}{plus} documents are valid JSON, so existing JSON tooling continues to work on JSON{plus}{plus} files.
+The `jq{plus}{plus}` tool evaluates a JSON{plus}{plus} file and emits ordinary JSON.
 
 === Special Keys
 


### PR DESCRIPTION
## Summary

- Introduces **structural composition** as a named sub-category of structural reuse, covering `$extends` and `$includes`
- Establishes a clear two-level hierarchy throughout all documentation:

  ```
  Structural reuse
   ├─ structural composition
   │   ├─ inheritance ($extends)
   │   └─ inclusion ($includes)
   └─ expression evaluation (eval:)
  ```

- No functional changes — documentation only.

## Changes per file

| File | Change |
|------|--------|
| `concepts/terminology.adoc` | New umbrella definition with hierarchy diagram; new "Structural Composition" section; fixed `eval:` timing sentence to say "after all **structural composition** has been resolved" |
| `manual/structural-reuse.adoc` | Clarified the page covers structural composition; named structural reuse as the broader umbrella |
| `concepts/overview.adoc` | Used "structural reuse" as umbrella in tool one-liner; dropped redundant "and expression evaluation" in YAML-workflow sentence |
| `concepts/design-principles.adoc` | Split Principle 3 body to attribute structural composition to `$extends`/`$includes` and expression evaluation to `eval:` |
| `reference/syntax-reference.adoc` | Renamed "structural reuse" → "structural composition" in mechanism list; added sentence defining structural reuse as the union of the two |

## Test plan

- [x] Review each changed file to confirm terminology is consistent with the hierarchy
- [x] Confirm no keyword (`$extends`, `$includes`, `eval:`) was renamed
- [x] Confirm existing examples and explanations remain readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)