### PR TITLE
Normalize plusplus markup in evaluation model docs

### DIFF
--- a/tools/etc/docs/concepts/design-principles.adoc
+++ b/tools/etc/docs/concepts/design-principles.adoc
@@ -11,7 +11,7 @@ For any valid JSON document _J_, there exists a JSON{plus}{plus} document _X_ su
 In other words, the evaluation function is surjective onto JSON.
 This property ensures that JSON{plus}{plus} can generate any configuration expected by downstream systems, allowing `jq{plus}{plus}` to be introduced as a pre-processing step without reducing expressiveness.
 
-In practice, this means that adopting JSON{plus}{plus} never forces downstream tools to change their expectations about the resulting configuration structure.footnote:[All JSON{plus}{plus} meta-keywords are escapable.]
+In practice, this means that adopting JSON{plus}{plus} never forces downstream tools to change their expectations about the resulting configuration structure.footnote:[`raw:` is the guaranteed escape mechanism for values or keys that would otherwise be treated as JSON{plus}{plus} control syntax. jq{plus}{plus} also keeps inheritance-time keywords in the `$...` namespace and treats new keyword families as a major-version compatibility change.]
 
 **All JSON{plus}{plus} documents are valid JSON:**
 Moreover, JSON{plus}{plus} documents remain valid JSON, which allows existing parsers and tooling to process them without modification.
@@ -30,4 +30,3 @@ JSON{plus}{plus} introduces explicit constructs for expressing structural reuse.
 
 * *Structural composition* constructs (`$extends`, `$includes`) let configurations combine documents directly, describing relationships in the data structure itself rather than through external tooling.
 * *Expression evaluation* (`eval:`) lets configurations compute values dynamically from the composed result.
-

--- a/tools/etc/docs/concepts/evaluation-model.adoc
+++ b/tools/etc/docs/concepts/evaluation-model.adoc
@@ -1,11 +1,11 @@
-== jq++ Design
+== jq{plus}{plus} Design
 
-This page describes the internal architecture of `jq++`, the tool that evaluates JSON++ configurations.
-For the design principles behind JSON++, see the link:design-principles.html[Design Principles] page.
+This page describes the internal architecture of `jq{plus}{plus}`, the tool that evaluates JSON{plus}{plus} configurations.
+For the design principles behind JSON{plus}{plus}, see the link:design-principles.html[Design Principles] page.
 
 === Evaluation Pipeline
 
-`jq++` transforms a JSON++ configuration file into plain JSON through a deterministic sequence of stages.
+`jq{plus}{plus}` transforms a JSON{plus}{plus} configuration file into plain JSON through a deterministic sequence of stages.
 Each stage reads from the result of the previous one; no stage revisits earlier work.
 
 [ditaa]
@@ -87,7 +87,7 @@ YAML, TOML, JSON5, and HOCON files are decoded by their respective parsers and t
 The module name is the base filename without the extension.
 Any `eval:` expression in a file that includes such a `.jq` file via `$extends` or `$includes` can call functions defined in that module.
 
-Files with no extension or with `.json++`, `.yaml++`, `.toml++`, `.json5++`, `.conf++`, or `.hocon++` are treated the same as their base format.
+Files with no extension or with `.json{plus}{plus}`, `.yaml{plus}{plus}`, `.toml{plus}{plus}`, `.json5{plus}{plus}`, `.conf{plus}{plus}`, or `.hocon{plus}{plus}` are treated the same as their base format.
 
 ==== Stage 2 — File-level inheritance
 
@@ -96,8 +96,8 @@ Both directives are handled by the same underlying merge engine; the difference 
 
 *Resolving parents*
 
-For each filename listed in `$extends` or `$includes`, `jq++` resolves the file against the search path (current file's directory → local node search paths → `JF_PATH`), then recursively applies the full pipeline (stages 1–4) to that parent file.
-The result is cached in a _node pool_ so that each file is evaluated at most once per `jq++` invocation, even when it is referenced from multiple places.
+For each filename listed in `$extends` or `$includes`, `jq{plus}{plus}` resolves the file against the search path (current file's directory → local node search paths → `JF_PATH`), then recursively applies the full pipeline (stages 1–4) to that parent file.
+The result is cached in a _node pool_ so that each file is evaluated at most once per `jq{plus}{plus}` invocation, even when it is referenced from multiple places.
 
 Circular inheritance chains are detected by tracking visited absolute paths.
 If a file that is already being resolved appears again in the chain, an error is reported immediately.
@@ -119,7 +119,7 @@ In other words, `$includes` fragments override everything that `$extends` and th
 
 ==== Stage 3 — Materialize local nodes
 
-Objects defined under the `$local` key are extracted and written as individual files in a temporary _session directory_ that is created fresh for each top-level `jq++` invocation.
+Objects defined under the `$local` key are extracted and written as individual files in a temporary _session directory_ that is created fresh for each top-level `jq{plus}{plus}` invocation.
 Each local node name becomes its own file (e.g. `BaseThing` becomes a file `BaseThing` with no extension, treated as JSON).
 
 The session directory is placed on the front of the search path for the duration of processing.
@@ -155,7 +155,7 @@ All string values in the object that start with `eval:` or `raw:` are evaluated.
 
 - A `raw:` value has its prefix stripped; the remaining string is the final value.
 - An `eval:` value is compiled and executed as a jq expression against the current full object as input.
-  The expression has access to the builtin variables `$cur` and `$curexpr`, and to the JSON++ builtin functions (`ref`, `refexpr`, `reftag`, `parent`, `parentof`, `topatharray`, `topathexpr`, `readfile`).
+  The expression has access to the builtin variables `$cur` and `$curexpr`, and to the JSON{plus}{plus} builtin functions (`ref`, `refexpr`, `reftag`, `parent`, `parentof`, `topatharray`, `topathexpr`, `readfile`).
 
 An `eval:` result may itself be a string starting with `eval:` (for example, when a value is resolved via `ref` and the referenced value is also an expression).
 The stage therefore loops, decrementing its own time-to-live counter (starting at 7) on each pass, re-evaluating until no `eval:` strings remain.
@@ -166,13 +166,13 @@ Circular references within expressions—where evaluating value A leads back to 
 
 The fully resolved `map[string]any` object is serialised to JSON with two-space indentation and written to standard output.
 When multiple input files are provided on the command line, each is processed independently and its output is written in order.
-When no file arguments are given, `jq++` reads from standard input, writing the input to a temporary file first (since the inheritance resolution needs a filesystem path to anchor relative file references).
+When no file arguments are given, `jq{plus}{plus}` reads from standard input, writing the input to a temporary file first (since the inheritance resolution needs a filesystem path to anchor relative file references).
 
 ---
 
 === Node Pool and Caching
 
-The node pool is the shared state that persists across all recursive inheritance resolutions within a single `jq++` invocation.
+The node pool is the shared state that persists across all recursive inheritance resolutions within a single `jq{plus}{plus}` invocation.
 Its two main responsibilities are:
 
 *Caching.*

--- a/tools/etc/docs/concepts/terminology.adoc
+++ b/tools/etc/docs/concepts/terminology.adoc
@@ -1,7 +1,7 @@
-== JSON++ Terminology
+== JSON{plus}{plus} Terminology
 
-This document defines the canonical terms used throughout the JSON++ documentation.
-When describing JSON++ behaviour, always prefer these terms over informal alternatives such as _templating_ or _rendering_.
+This document defines the canonical terms used throughout the JSON{plus}{plus} documentation.
+When describing JSON{plus}{plus} behaviour, always prefer these terms over informal alternatives such as _templating_ or _rendering_.
 
 === Structural Reuse
 
@@ -24,7 +24,7 @@ Structural reuse
 === Structural Composition
 
 _Structural composition_ is the subset of structural reuse that combines configuration documents structurally.
-JSON++ provides two structural-composition constructs: *inheritance* (`$extends`) and *inclusion with defaults* (`$includes`).
+JSON{plus}{plus} provides two structural-composition constructs: *inheritance* (`$extends`) and *inclusion* (`$includes`).
 
 === Inheritance (`$extends`)
 
@@ -45,13 +45,13 @@ When multiple parents are listed, earlier entries in the `$extends` array take p
 
 Priority from highest to lowest: current object → first parent → … → last parent.
 
-=== Inclusion with Defaults (`$includes`)
+=== Inclusion (`$includes`)
 
-*Inclusion with defaults* is the mechanism by which an object pulls in one or more external fragments that act as authoritative defaults.
-Unlike inheritance, where the derived object overrides its parents, the included fragments override the including object's own fields.
+*Inclusion* is the mechanism by which an object pulls in one or more external fragments that are applied on top of the including object.
+Unlike inheritance, where the current object overrides its parents, inclusion gives higher priority to the included fragments.
 
-*Precedence direction: included fragments override the including object.*
-The including object provides initial values; the included fragments are applied on top, overriding those values.
+*Precedence direction: included fragments → including object.*
+The including object provides the starting values; the included fragments are then applied on top, overriding those values.
 When multiple fragments are listed, later entries in the `$includes` array take precedence over earlier ones.
 
 [source,json]
@@ -86,10 +86,11 @@ The expression is evaluated against the current JSON root after all structural c
 Expression evaluation applies to both values and keys.
 When a key expression evaluates to an array of strings, one key–value pair is emitted per element.
 
-=== Escaping Meta Keys (`raw:`)
+=== Escaping Meta Keywords (`raw:`)
 
 *Escaping* is the mechanism by which a string value or key prefixed with `raw:` is passed through to the output with the prefix stripped, without any evaluation.
-This is necessary when a value or key would otherwise be interpreted as an `eval:` expression or when a key matches a JSON++ reserved word such as `$extends`, `$includes`, or `$local`.
+This is the guaranteed way to preserve a value or key that would otherwise be interpreted as an `eval:` expression or as a JSON{plus}{plus} reserved keyword such as `$extends`, `$includes`, or `$local`.
+In practice, jq{plus}{plus} keeps inheritance-time control keywords in the `$...` namespace and treats new keyword families as a major-version compatibility concern, so accidental collisions should remain rare.
 
 [source,json]
 ----

--- a/tools/etc/docs/manual/structural-reuse.adoc
+++ b/tools/etc/docs/manual/structural-reuse.adoc
@@ -3,7 +3,7 @@
 JSON{plus}{plus} provides *structural reuse* mechanisms that allow configurations to be constructed from reusable fragments.
 Structural reuse consists of *structural composition* (`$extends` and `$includes`) and *expression evaluation* (`eval:`).
 
-This page focuses on *structural composition*: the two constructs that combine configuration documents — *inheritance* (`$extends`) and *inclusion with defaults* (`$includes`).
+This page focuses on *structural composition*: the two constructs that combine configuration documents — *inheritance* (`$extends`) and *inclusion* (`$includes`).
 
 For precise definitions and precedence rules see the link:../concepts/terminology.html[Terminology] page.
 For the full syntax of each construct see the link:../reference/syntax-reference.html[Syntax Reference].

--- a/tools/etc/docs/reference/syntax-reference.adoc
+++ b/tools/etc/docs/reference/syntax-reference.adoc
@@ -1,4 +1,4 @@
-== JSON++ Syntax Reference
+== JSON{plus}{plus} Syntax Reference
 
 JSON{plus}{plus} is a lightweight extension of JSON that adds three mechanisms to standard JSON:
 
@@ -12,10 +12,81 @@ Structural composition and expression evaluation together form *structural reuse
 All JSON{plus}{plus} documents are valid JSON, so existing JSON tooling continues to work on JSON{plus}{plus} files.
 The `jq{plus}{plus}` tool evaluates a JSON{plus}{plus} file and emits ordinary JSON.
 
-=== Special Keys
+=== Semantic Summary
 
-JSON++ uses a small set of reserved keys—all prefixed with `$`—to express structural relationships.
-These keys are consumed during evaluation and do not appear in the output.
+[cols="1,2,3,2", options="header"]
+|===
+|Construct
+|Role
+|Behavior
+|Constraints / Notes
+
+|`$extends: [f1, f2, ...]`
+|Inheritance
+|Derives the current object from one or more parent definitions.
+Parents are resolved recursively, merged in listed order, and then overridden by the current object's own fields.
+|Earlier parents take precedence over later ones.
+Priority is: current object -> first parent -> ... -> last parent.
+Circular resolution is rejected.
+
+|`$includes: [f1, f2, ...]`
+|Inclusion
+|Applies external fragments on top of the current object after `$extends` has been resolved.
+This is the opposite precedence direction from `$extends`.
+|Later included fragments take precedence over earlier ones.
+Priority is: last fragment -> ... -> first fragment -> current object.
+If both `$extends` and `$includes` are present, `$includes` wins over the combined result.
+
+|`$local`
+|Local node definitions
+|Defines reusable named objects inside the current file.
+Each local node is materialized into a temporary session-local file and can then be referenced by bare name from `$extends` or `$includes`.
+|`$local` is removed from the final output.
+Scope is limited to the object tree rooted at the file that defined it.
+
+|`"eval:<jq-expr>"` and `"eval:<type>:<jq-expr>"`
+|Expression evaluation
+|A string value starting with `eval:` is compiled as a jq expression and evaluated against the fully composed JSON object.
+The result replaces the original string.
+|Value-side evaluation happens after structural composition and after key-side evaluation.
+Without a type annotation, the result must be a string.
+If the result is another `eval:` string, jq{plus}{plus} re-evaluates it up to a fixed iteration limit.
+
+|`"eval:<jq-expr>"` as a key
+|Computed keys
+|A key starting with `eval:` is evaluated and replaced with the resulting key name.
+If the expression yields an array of strings, one key is emitted per element.
+|Key-side evaluation runs before value-side evaluation.
+When evaluating a key, `$cur` points to the parent object.
+
+|`raw:`
+|Escaping
+|A key or string value starting with `raw:` is passed through unchanged except that the prefix is removed.
+|Guaranteed escape hatch for literal control-like strings and reserved keywords.footnote:[`raw:` is the formal, guaranteed way to preserve values or keys that would otherwise be treated as JSON{plus}{plus} control syntax. In practice, jq{plus}{plus} keeps inheritance-time control keywords in the `$...` namespace, and introducing new reserved prefixes or new keyword families is treated as a major-version compatibility change.]
+
+|Evaluation order
+|Resolution sequencing
+|jq{plus}{plus} first resolves file-level `$extends` / `$includes`, then materializes `$local`, then resolves nested `$extends` / `$includes`, then evaluates keys, and finally evaluates values.
+|This ordering makes precedence deterministic and ensures expressions see the fully composed structure.
+
+|`JF_PATH`
+|File resolution
+|Referenced files are resolved using jq{plus}{plus}'s search path.
+|Resolution order is: current file directory -> active local-node directories -> `JF_PATH` entries.
+`JF_PATH` supplements, rather than replaces, relative resolution.
+
+|Output guarantee
+|JSON output
+|jq{plus}{plus} is a preprocessing step only.
+The result of evaluating JSON{plus}{plus} is always ordinary JSON.
+|Downstream tools consume the output exactly as JSON; JSON{plus}{plus} constructs do not survive evaluation unless explicitly escaped with `raw:`.
+|===
+
+=== Special Keywords
+
+JSON{plus}{plus} uses a small set of reserved keywords to express control semantics during evaluation.
+At present, the inheritance-time keywords are prefixed with `$`.
+These keywords are consumed during evaluation and do not appear in the output unless escaped.
 
 ==== $extends
 
@@ -69,8 +140,8 @@ If the file does not exist, it is silently skipped.
 
 ==== $includes
 
-Declares that the current object includes one or more external fragments as authoritative defaults.
-Unlike `$extends`, where the derived object overrides its parents, `$includes` inverts the relationship: the current object's own fields serve as defaults that the included fragments can override.
+Declares that the current object includes one or more external fragments to be applied on top of it.
+Unlike `$extends`, where the current object overrides its parents, `$includes` gives higher priority to the included fragments than to the including object's own fields.
 
 *Syntax*
 
@@ -116,7 +187,7 @@ Any configuration file can then pull in exactly the behaviour it needs with a si
 }
 ----
 
-Running `JF_PATH=/opt/myapp/lib jq++ service.json` resolves `defaults/runtime.json` and `defaults/logging.json` from the library directory.
+Running `JF_PATH=/opt/myapp/lib jq{plus}{plus} service.json` resolves `defaults/runtime.json` and `defaults/logging.json` from the library directory.
 Switching environments is a matter of changing `JF_PATH`—the configuration files themselves are untouched.
 
 This pattern lets teams publish versioned "standard" fragments that any project can `$includes` without copying content.
@@ -283,11 +354,13 @@ Output:
 }
 ----
 
-*Tip — escaping reserved keys*
+*Tip — escaping reserved keywords*
 
-`raw:` is the only way to produce a literal key (or value) that starts with a JSON++ reserved prefix such as `$extends`, `$includes`, or `$local`.
-Because these strings are consumed by jq++ before output, a bare `"$extends"` key cannot survive into the final JSON.
-Prefix it with `raw:` to pass it through unchanged.
+`raw:` is the formal, guaranteed way to produce a literal key (or value) that would otherwise match a JSON{plus}{plus} control prefix such as `eval:` or a reserved keyword such as `$extends`, `$includes`, or `$local`.
+Because these strings are interpreted by jq{plus}{plus} during evaluation, prefixing with `raw:` is the portability-safe way to ensure they survive unchanged in the final JSON.
+
+In practice, jq{plus}{plus} keeps inheritance-time control keywords in the `$...` namespace, and introducing new reserved prefixes or new keyword families is treated as a major-version compatibility change.
+That policy makes accidental collisions unlikely, but `raw:` remains the documented escape hatch.
 
 [source,json]
 ----
@@ -339,11 +412,11 @@ In standard jq, a _path expression_ (e.g. `.foo.bar[0]`) is a syntactic construc
 It exists only at the language level—as a fragment of source code—and cannot be stored in a variable, passed as an argument, or returned from a function.
 Functions such as `path/1`, `getpath/1`, and `setpath/1` accept _path arrays_ (plain JSON arrays of strings and integers) precisely because path expressions are not first-class data.
 
-JSON++ intentionally departs from this principle.
+JSON{plus}{plus} intentionally departs from this principle.
 `$cur` and `$curexpr` expose the current location as runtime values, and `topatharray`/`topathexpr` let you convert between the two representations freely.
 This is a deliberate usability trade-off: configuration authors need to navigate and reference locations in the document, and string-based path expressions are considerably more readable than raw path arrays when written inside a JSON string.
 
-Treating path expressions as strings is therefore a JSON++-specific convention.
+Treating path expressions as strings is therefore a JSON{plus}{plus}-specific convention.
 It has no meaning to jq itself; the conversion functions bridge the gap when you need to pass a location to a jq built-in such as `getpath` or `setpath`.
 ====
 
@@ -486,7 +559,7 @@ The result is the parsed JSON value (object, array, string, number, boolean, or 
 
 === Supported Input Formats
 
-`jq++` accepts files in any of the following formats.
+`jq{plus}{plus}` accepts files in any of the following formats.
 The format is determined from the file extension.
 
 [cols="1,2"]
@@ -502,11 +575,11 @@ The format is determined from the file extension.
 |===
 
 YAML, TOML, JSON5, and HOCON files are converted to the JSON data model before processing; the same JSON{plus}{plus} directives work in all formats.
-The `{plus}{plus}` suffix variants (`.json++`, `.yaml++`, etc.) are treated identically to their base extensions.
+The `++` suffix variants (`.json++`, `.yaml++`, etc.) are treated identically to their base extensions.
 
 === Search Paths
 
-When resolving filenames in `$extends`, `$includes`, and `readfile()`, `jq++` searches directories in the following order:
+When resolving filenames in `$extends`, `$includes`, and `readfile()`, `jq{plus}{plus}` searches directories in the following order:
 
 1. The directory of the file that contains the reference.
 2. Directories listed in the `JF_PATH` environment variable, separated by `:` (colon).
@@ -515,7 +588,7 @@ This mirrors the behavior of environment variables such as `PATH` or `PYTHONPATH
 
 [source,shell script]
 ----
-$ JF_PATH=/shared/configs:/team/defaults jq++ myconfig.json
+$ JF_PATH=/shared/configs:/team/defaults jq{plus}{plus} myconfig.json
 ----
 
 See the link:../concepts/evaluation-model.html[Design] page for a detailed description of the evaluation pipeline.

--- a/tools/etc/docs/reference/syntax-reference.adoc
+++ b/tools/etc/docs/reference/syntax-reference.adoc
@@ -42,7 +42,7 @@ If both `$extends` and `$includes` are present, `$includes` wins over the combin
 |Defines reusable named objects inside the current file.
 Each local node is materialized into a temporary session-local file and can then be referenced by bare name from `$extends` or `$includes`.
 |`$local` is removed from the final output.
-Scope is limited to the object tree rooted at the file that defined it.
+Local nodes are visible within the composed subtree of the defining file.
 
 |`"eval:<jq-expr>"` and `"eval:<type>:<jq-expr>"`
 |Expression evaluation


### PR DESCRIPTION
## Summary
- replace remaining literal  spellings in  with 
- normalize  and  references in that page
- make the generated HTML consistent with the rest of the documentation

## Testing
- not run (documentation-only change)
