### PR TITLE
Document plusplus markup convention for docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS
+
+## Documentation Notes
+
+- In AsciiDoc documentation, prefer `JSON{plus}{plus}` and `jq{plus}{plus}` over literal `JSON++` and `jq++`.
+- This also applies inside backticks and other inline markup in `.adoc` files, where literal `++` may render incorrectly or disappear in generated HTML.
+- For filename extensions and concrete command/file examples where the literal text matters, keep the real spelling such as `.json++` or `jq++` if that is what users must type.


### PR DESCRIPTION
## Summary
- add a repo-level AGENTS.md note for AsciiDoc authoring
- document when to use {plus}{plus} instead of literal ++ in docs
- keep literal jq++ and .json++ spellings only where users must type the exact text

## Testing
- not run (documentation-only change)
