### PR TITLE
test: add readfile missing-file diagnostic coverage

### DIFF
--- a/tools/etc/autotest/templating/builtin-functions/readfile/negative/file-not-found/expected.txt
+++ b/tools/etc/autotest/templating/builtin-functions/readfile/negative/file-not-found/expected.txt
@@ -1,0 +1,3 @@
+file does not exist
+readfile
+nonexistent\.json

--- a/tools/etc/autotest/templating/builtin-functions/readfile/negative/file-not-found/input.json
+++ b/tools/etc/autotest/templating/builtin-functions/readfile/negative/file-not-found/input.json
@@ -1,0 +1,3 @@
+{
+  "content": "eval:object:readfile(\"nonexistent.json\")"
+}

--- a/tools/etc/autotest/templating/builtin-functions/readfile/negative/file-not-found/test.json
+++ b/tools/etc/autotest/templating/builtin-functions/readfile/negative/file-not-found/test.json
@@ -1,0 +1,3 @@
+{
+  "testType": "negative"
+}


### PR DESCRIPTION
## Summary

Adds a negative autotest for `eval:object:readfile("nonexistent.json")`.

## Why

Issue #69 identified a stale diagnostic expectation. The current diagnostic deliberately reports the failure condition together with the `readfile` expression and requested filename. The fixture now asserts those stable, actionable fragments instead of legacy wording and quoting.

## Root cause

The test fixture was absent from the default branch, while the desired assertion used an older `file not found` format that no longer matches the current diagnostic contract.

## Validation

- `go test ./...`
- Ran `go run ./cmd/jqplusplus tools/etc/autotest/templating/builtin-functions/readfile/negative/file-not-found/input.json` and verified each expected regex fragment matches stderr.

Fixes #69.
