### PR TITLE
docs: clarify object vs array merge semantics at first mention (#63)

### DIFF
--- a/tools/etc/docs/concepts/evaluation-model.adoc
+++ b/tools/etc/docs/concepts/evaluation-model.adoc
@@ -105,8 +105,30 @@ If a file that is already being resolved appears again in the chain, an error is
 *Merge semantics*
 
 `mergeObjects(parent, child)` combines two objects, with the child's values taking precedence.
-The merge is recursive for nested objects: if both parent and child have a key whose value is an object, those objects are merged recursively rather than the child object replacing the parent object wholesale.
-For any other value type (string, number, boolean, array, null), the child value simply replaces the parent value.
+How each key is combined depends on the type of its value:
+
+[cols="1,2", options="header"]
+|===
+|Value type |Behavior
+
+|Object
+|Recursive merge — parent and child objects are combined key by key using this same rule.
+
+|Array
+|Replaced entirely — the child array overrides the parent; arrays are never merged element-wise.
+
+|Scalar (string, number, boolean, null)
+|Replaced entirely — the child value overrides the parent value.
+|===
+
+"Recursive" therefore applies only to nested objects; arrays and scalars are always replaced wholesale, never merged.
+
+[NOTE]
+====
+Array replacement is the current behavior.
+We are considering enhancing the syntax so that a child can explicitly *append*, *prepend*, or *merge* an array with the one inherited from its ancestors, instead of always replacing it.
+This is a future consideration and not yet supported.
+====
 
 Given `$extends: [A, B]`, A is merged over B first, then the current object is merged over that result, giving the priority order: current object → A → B.
 


### PR DESCRIPTION
## Summary

Resolves #63.

The first "Merge semantics" description in `evaluation-model.adoc` led with *"recursive for nested objects"*, which primes readers to assume arrays are deep-merged (a common convention in JSON/YAML tooling). The unambiguous clarification — *"a child array replaces the parent array completely"* — only appeared ~80 lines later in the appendix.

## Changes

- Add a **type → behavior table** at the first mention:

  | Value type | Behavior |
  | --- | --- |
  | Object | Recursive merge |
  | Array | Replaced entirely |
  | Scalar | Replaced entirely |

- Add a clarifying sentence that "recursive" applies only to nested objects.
- Add a `NOTE` admonition flagging a **future consideration**: enhancing the syntax so a child can explicitly *append* / *prepend* / *merge* an array inherited from ancestors instead of always replacing it (not yet supported).

Docs-only change; the detailed "Merge Object Semantics" appendix is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)