### PR TITLE
docs: document the same-kind merge principle

### DIFF
--- a/tools/etc/docs/concepts/design-principles.adoc
+++ b/tools/etc/docs/concepts/design-principles.adoc
@@ -1,6 +1,6 @@
 == Design Principles
 
-JSON{plus}{plus} was designed around three principles.
+JSON{plus}{plus} was designed around four principles.
 
 === Principle 1 — Completeness and Compatibility
 
@@ -30,3 +30,21 @@ JSON{plus}{plus} introduces explicit constructs for expressing structural reuse.
 
 * *Structural composition* constructs (`$extends`, `$includes`) let configurations combine documents directly, describing relationships in the data structure itself rather than through external tooling.
 * *Expression evaluation* (`eval:`) lets configurations compute values dynamically from the composed result.
+
+=== Principle 4 — Same-Kind Merge
+
+**A merge is defined only between two values of the same kind:**
+When jq{plus}{plus} combines two values by merging, both values must be of the same kind: object with object, array with array, or atom with atom.
+Strings, numbers, booleans, and `null` are all atoms.
+jq{plus}{plus} never merges values across kinds.
+Where a construct requests a merge and the operand kinds differ, jq{plus}{plus} reports a configuration error rather than guessing an outcome.
+
+This principle rests on the distinction between _overriding_ and _merging_:
+
+* An *override* replaces the inherited value entirely.
+  Writing a key in a child object means "override"; no kind constraint applies, and the child value wins regardless of its type.
+* A *merge* combines the inherited value with the child value.
+  Merging is only meaningful within a kind, so requesting it across kinds is a contradiction to be reported, not a replacement to be performed silently.
+
+Today the only merge the engine performs is between two objects; every other combination during inheritance is an override.
+Future constructs that extend merging to arrays and atoms are bound by this principle: they merge within a kind and report an error across kinds.

--- a/tools/etc/docs/concepts/evaluation-model.adoc
+++ b/tools/etc/docs/concepts/evaluation-model.adoc
@@ -122,6 +122,8 @@ How each key is combined depends on the type of its value:
 |===
 
 "Recursive" therefore applies only to nested objects; arrays and scalars are always replaced wholesale, never merged.
+In jq{plus}{plus} terminology these wholesale replacements are _overrides_: the only _merge_ the engine performs is between two objects.
+This is the link:design-principles.html[same-kind merge principle].
 
 [NOTE]
 ====
@@ -218,3 +220,4 @@ The full search path at any point is: current file's base directory + local node
 
 This means arrays are **not** merged—a child array replaces the parent array completely.
 Only nested objects receive the recursive treatment.
+This follows the link:design-principles.html[same-kind merge principle]: merging is defined only between values of the same kind, and every cross-kind combination is an override that replaces the value rather than a merge.


### PR DESCRIPTION
## Summary

Resolves #76.

- Adds **Principle 4 — Same-Kind Merge** to `design-principles.adoc`: a merge is defined only between two values of the same kind (object×object, array×array, atom×atom); cross-kind merge requests are configuration errors. Includes the **override vs merge** distinction: overrides (writing a key) are kind-free and child-wins; merges are same-kind only.
- Notes that current behavior already conforms: object×object is the only merge the engine performs; every other combination during inheritance is an override.
- Cross-references the principle from both merge-semantics sections of `evaluation-model.adoc`.

The principle constrains the future array-composition constructs designed in #74 without changing any current behavior. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)