### PR TITLE
docs: document the OpenSpec development workflow

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,0 +1,36 @@
+= Contributing to jq{plus}{plus}
+
+Thank you for your interest in jq{plus}{plus}.
+
+== How This Project Is Built
+
+This project uses link:https://github.com/Fission-AI/OpenSpec[OpenSpec] for spec-driven development.
+Behaviour is specified before it is implemented, and the specification lives in the repository under `openspec/`.
+
+Read link:tools/etc/docs/development/workflow.adoc[Development Workflow] before opening a pull request.
+It covers the activities and artifacts, where the contract lives, what belongs in an issue, and how pull requests are split.
+
+== Quick Reference
+
+Filing an issue::
+Describe the pain, not the solution.
+See the issues section of the development workflow.
+
+Proposing a change::
+Planning artifacts are written and reviewed first, in their own pull request, before any code is written.
+
+Implementing::
+One pull request per phase in `tasks.md`, merged in order.
+
+== Building and Testing
+
+[source,bash]
+----
+make build
+make test
+----
+
+== Documentation Conventions
+
+Documentation conventions for agents and contributors are recorded in link:AGENTS.md[AGENTS.md].
+In particular, prefer `JSON{plus}{plus}` and `jq{plus}{plus}` over the literal spellings in AsciiDoc, and define each term at first use or link to `tools/etc/docs/concepts/terminology.adoc`.

--- a/tools/etc/docs/development/workflow.adoc
+++ b/tools/etc/docs/development/workflow.adoc
@@ -1,0 +1,154 @@
+== Development Workflow
+:imagesdir: ../images
+:data-uri:
+
+This project uses link:https://github.com/Fission-AI/OpenSpec[OpenSpec] for spec-driven development.
+This page describes how OpenSpec, GitHub issues, and pull requests fit together.
+
+It documents how the project is _built_.
+For documentation of the JSON{plus}{plus} language itself, see the concepts and manual pages.
+
+=== Activities and Artifacts
+
+image::openspec-workflow.svg[OpenSpec workflow,1120]
+
+In the diagram, ovals are _activities_ and boxes are _artifacts_.
+Every arrow starts at an activity: a solid arrow means the activity reads the artifact, and a dashed arrow means it writes to it.
+
+Two artifacts are outside the repository.
+
+* The *GitHub Issue* is optional and lives on GitHub.
+* *Memory* is volatile: it is the understanding of what to build, held in a human's head or an agent's context, and it survives nothing.
+
+Everything else is a file under version control.
+
+=== Where the Contract Lives
+
+The specification is the contract, and it lives in exactly one place at a time.
+
+* While a change is in progress, in `openspec/changes/<change-id>/specs/<capability>/spec.md`, written as a delta.
+* After the change is archived, in `openspec/specs/<capability>/spec.md`, merged into the current truth.
+
+Nothing else is normative.
+Neither the issue, nor `proposal.md`, nor `design.md` states what the system must do.
+When a document and the implementation disagree, that is a decision to be made, not a discrepancy to be silently edited away.
+
+=== The Three Planning Artifacts
+
+The artifacts differ in what they are _about_, not in who writes them.
+
+`proposal.md`::
+The problem, the chosen direction at headline level, which capabilities are affected, and what is out of scope.
+
+`specs/` delta::
+Externally observable behaviour, as requirements and scenarios.
+This is the external design.
+
+`design.md`::
+The internal approach — data structures, algorithms, risks, and rejected alternatives.
+This is the internal design.
+
+Requirements use a fixed shape that `openspec validate --strict` enforces.
+
+[source,markdown]
+----
+### Requirement: Name
+The system SHALL <observable behavior>.
+
+#### Scenario: Specific case
+- GIVEN <state>
+- WHEN <action>
+- THEN <observable outcome>
+----
+
+=== Issues
+
+An issue records a _pain_, not a solution.
+
+* State who is affected, what they cannot do today, and why it matters.
+* Do not state the mechanism, the syntax, or the data model.
+* Avoid acceptance criteria that read like scenarios; the spec delta is the only normative statement of behaviour.
+
+File an issue when the pain is noticed, not when there is time to work on it.
+Not every issue becomes a change, and a small self-evident change needs no issue.
+
+At archive time, close the issue with a pointer to the specification that now answers it.
+Do not copy the conclusion into the issue: two documents claiming to be the specification will drift.
+
+=== Pull Requests
+
+Planning and implementation are separated, so that design is reviewed as markdown before it is reviewed as code.
+
+. *PR 1 — planning.*
+Contains only `openspec/changes/<change-id>/`.
+Merged *before* any implementation begins.
+This is where semantics are argued.
+. *PR 2 to n — implementation.*
+One per phase in `tasks.md`, merged in order.
+Each ticks off its own checkboxes.
+. *Final PR — archive.*
+The delta is merged into `openspec/specs/` and the change folder is moved.
+This is the moment the recorded truth changes, so it is reviewed on its own.
+
+Merging PR 1 into `main` does not make `main` lie.
+`openspec/changes/` is by definition pending work; only `openspec/specs/` claims to describe reality.
+
+Two consequences worth knowing.
+
+* `tasks.md` is shared state, so concurrent implementation PRs conflict.
+Sequence them.
+* If implementation shows the spec was wrong, amend the spec in its own PR before continuing.
+That makes the change visible as a decision.
+
+Branch names follow the existing convention, `<type>/<slug>-<issue>`, for example `spec/array-composition-84`.
+
+=== Commands
+
+The activities are driven by slash commands given to a coding agent.
+The `openspec` CLI is what the agent calls underneath, and what a human uses for inspection.
+
+|===
+| Activity | Slash command | Notes
+
+| explore
+| `/opsx:explore`
+| Conversation only; writes no artifact.
+
+| propose
+| `/opsx:propose`
+| Generates all four planning artifacts at once.
+
+| propose, incrementally
+| `/opsx:new` then `/opsx:continue`
+| One artifact at a time, so each can be reviewed.
+
+| revise
+| `/opsx:update`
+| Edits existing artifacts and propagates the change to the others.
+
+| apply
+| `/opsx:apply`
+| Implements tasks and ticks the checkboxes.
+
+| verify
+| `/opsx:verify`
+| Compares code against the artifacts; reports findings, never blocks.
+
+| archive
+| `/opsx:archive`
+| Merges the delta into `openspec/specs/`.
+|===
+
+For inspection outside any activity: `openspec list`, `openspec show`, `openspec status`, `openspec view`.
+`openspec validate --strict` is the structural check and is suitable for CI.
+
+=== Notes on Two Steps That Are Easy to Misread
+
+`explore` writes nothing.
+Its only output is understanding, which is why the diagram shows it writing to volatile memory.
+Anything worth keeping — especially the alternatives that were considered and rejected — must be materialised in `proposal.md` or `design.md`, or it is lost.
+
+`verify` is a judgement made by a language model, not a structural check.
+It reads the artifacts and the code and reports on completeness, correctness, and coherence.
+Treat its findings as a reviewer's opinion.
+The mechanical check is `openspec validate --strict`, and the objective check is the autotest suite.

--- a/tools/etc/docs/images/openspec-workflow.svg
+++ b/tools/etc/docs/images/openspec-workflow.svg
@@ -1,0 +1,186 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 960" width="1120" height="960" role="img" aria-label="OpenSpec workflow: activities and artifacts">
+  <title>OpenSpec workflow — activities and artifacts</title>
+  <defs>
+    <marker id="j1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="var(--border-stronger)"/>
+    </marker>
+    <marker id="j2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="var(--text-accent)"/>
+    </marker>
+  </defs>
+  <style>
+    svg {
+      --surface-0: #ffffff;
+      --surface-1: #f5f7fa;
+      --surface-2: #ffffff;
+      --border: #d6dae1;
+      --border-strong: #a9b1bd;
+      --border-stronger: #79838f;
+      --text-primary: #1b1f24;
+      --text-secondary: #414a54;
+      --text-muted: #6b7480;
+      --text-accent: #1f6feb;
+      --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+      font-family: var(--font-sans);
+      background: var(--surface-0);
+    }
+    @media (prefers-color-scheme: dark) {
+      svg {
+        --surface-0: #14181d;
+        --surface-1: #1b2027;
+        --surface-2: #232a33;
+        --border: #333c47;
+        --border-strong: #4b5765;
+        --border-stronger: #8b95a3;
+        --text-primary: #e8ecf1;
+        --text-secondary: #c2c9d2;
+        --text-muted: #9099a5;
+        --text-accent: #5aa0ff;
+      }
+    }
+    .art { fill: var(--surface-2); stroke: var(--border-strong); }
+    .act { fill: var(--surface-1); stroke: var(--text-accent); stroke-width: 1.5; }
+    .t   { font-size: 13px; font-weight: 600; fill: var(--text-primary); text-anchor: middle; }
+    .st  { font-size: 9.5px; font-weight: 700; fill: var(--text-accent); text-anchor: middle; letter-spacing: .3px; }
+    .s   { font-size: 10.5px; fill: var(--text-muted); text-anchor: middle; }
+    .rd  { fill: none; stroke: var(--border-stronger); stroke-width: 1.5; marker-end: url(#j1); }
+    .wr  { fill: none; stroke: var(--text-accent); stroke-width: 1.5; stroke-dasharray: 6 4; marker-end: url(#j2); }
+    .ch  { font-size: 12.5px; font-weight: 700; fill: var(--text-accent); letter-spacing: .3px; }
+    .cm  { font-size: 10.5px; font-family: var(--font-mono); fill: var(--text-primary); }
+    .cs  { font-size: 10px; fill: var(--text-muted); }
+    .cb  { font-size: 11px; font-weight: 700; fill: var(--text-primary); }
+    .grp { fill: none; stroke: var(--text-accent); stroke-width: 2; }
+    .gl  { font-size: 12px; font-weight: 700; fill: var(--text-accent); letter-spacing: .4px; }
+    .hd  { font-size: 15px; font-weight: 700; fill: var(--text-primary); }
+    .lg  { font-size: 10px; fill: var(--text-secondary); }
+    .lgc { font-size: 10px; fill: var(--text-primary); text-anchor: middle; }
+  </style>
+
+  <rect x="0" y="0" width="1120" height="960" fill="var(--surface-0)"/>
+  <text x="16" y="22" class="hd">OpenSpec — activities (ovals) and artifacts (boxes)</text>
+
+  <rect x="30" y="60" width="142" height="64" rx="7" fill="var(--surface-2)" stroke="var(--text-muted)" stroke-dasharray="3 3"/>
+  <text x="101" y="80" class="st">&#171;volatile&#187;</text>
+  <text x="101" y="97" class="t">memory</text>
+  <text x="101" y="112" class="s">understanding of</text>
+  <text x="101" y="123" class="s">what to build</text>
+
+  <ellipse cx="101" cy="190" rx="72" ry="26" class="act"/>
+  <text x="101" y="195" class="t">explore</text>
+  <path d="M101,164 L101,130" class="wr"/>
+  <path d="M101,216 L101,296" class="rd"/>
+
+  <rect x="30" y="302" width="142" height="58" rx="7" class="art" stroke-dasharray="5 4"/>
+  <text x="101" y="321" class="st">&#171;optional&#187;</text>
+  <text x="101" y="338" class="t">GitHub Issue</text>
+  <text x="101" y="353" class="s">the pain</text>
+  <path d="M236,320 L178,320" class="rd"/>
+  <path d="M236,92 L178,92" class="rd"/>
+  <path d="M580,864 L580,896 L190,896 L190,344 L178,344" class="wr"/>
+
+  <g transform="translate(180,0)">
+    <rect x="60" y="104" width="526" height="516" rx="16" class="grp"/>
+    <text x="74" y="126" class="gl">propose</text>
+
+    <rect x="200" y="42" width="240" height="50" rx="7" class="art"/>
+    <text x="320" y="64" class="t">openspec/specs/</text>
+    <text x="320" y="81" class="s">current truth — how it behaves today</text>
+
+    <ellipse cx="320" cy="150" rx="78" ry="30" class="act"/>
+    <text x="320" y="146" class="st">&#171;entry point&#187;</text>
+    <text x="320" y="163" class="t">new</text>
+    <path d="M320,120 L320,96" class="rd"/>
+    <path d="M320,180 L320,206" class="wr"/>
+
+    <rect x="210" y="212" width="220" height="46" rx="7" class="art"/>
+    <text x="320" y="232" class="t">proposal.md</text>
+    <text x="320" y="248" class="s">why + scope</text>
+
+    <ellipse cx="175" cy="320" rx="80" ry="26" class="act"/>
+    <text x="175" y="325" class="t">write spec</text>
+    <ellipse cx="470" cy="320" rx="80" ry="26" class="act"/>
+    <text x="470" y="325" class="t">write design</text>
+    <path d="M205,300 L258,262" class="rd"/>
+    <path d="M440,300 L387,262" class="rd"/>
+    <path d="M175,346 L175,380" class="wr"/>
+    <path d="M470,346 L470,380" class="wr"/>
+
+    <rect x="70" y="386" width="210" height="52" rx="7" class="art"/>
+    <text x="175" y="407" class="t">specs/ delta</text>
+    <text x="175" y="424" class="s">ADDED / MODIFIED / REMOVED</text>
+    <rect x="370" y="386" width="200" height="52" rx="7" class="art"/>
+    <text x="470" y="407" class="t">design.md</text>
+    <text x="470" y="424" class="s">internal approach</text>
+
+    <ellipse cx="320" cy="498" rx="78" ry="26" class="act"/>
+    <text x="320" y="503" class="t">write tasks</text>
+    <path d="M268,486 L196,446" class="rd"/>
+    <path d="M374,486 L448,446" class="rd"/>
+    <path d="M320,524 L320,554" class="wr"/>
+
+    <rect x="215" y="560" width="210" height="46" rx="7" class="art"/>
+    <text x="320" y="580" class="t">tasks.md</text>
+    <text x="320" y="596" class="s">- [ ] checkboxes</text>
+
+    <ellipse cx="320" cy="668" rx="88" ry="26" class="act"/>
+    <text x="320" y="673" class="t">apply (implement)</text>
+    <path d="M296,642 L296,610" class="rd"/>
+    <path d="M348,642 L348,610" class="wr"/>
+    <path d="M410,664 L464,664" class="wr"/>
+    <rect x="470" y="642" width="160" height="48" rx="7" class="art"/>
+    <text x="550" y="662" class="t">source code</text>
+    <text x="550" y="678" class="s">internal/, autotest/</text>
+    <path d="M232,670 L44,670 L44,424 L62,424" class="rd"/>
+
+    <ellipse cx="320" cy="752" rx="78" ry="26" class="act"/>
+    <text x="320" y="757" class="t">verify</text>
+    <path d="M242,752 L30,752 L30,412 L62,412" class="rd"/>
+    <path d="M392,740 L524,698" class="rd"/>
+
+    <ellipse cx="400" cy="838" rx="78" ry="26" class="act"/>
+    <text x="400" y="843" class="t">archive</text>
+    <path d="M400,864 L400,880 L16,880 L16,400 L62,400" class="rd"/>
+    <path d="M322,838 L306,838" class="wr"/>
+    <rect x="120" y="812" width="180" height="52" rx="7" class="art"/>
+    <text x="210" y="833" class="t">changes/archive/</text>
+    <text x="210" y="849" class="s">&lt;date&gt;-&lt;change-id&gt;/</text>
+    <path d="M478,832 L650,832 L650,67 L448,67" class="wr"/>
+  </g>
+
+  <rect x="850" y="296" width="252" height="142" rx="8" fill="var(--surface-1)" stroke="var(--border)"/>
+  <rect x="850" y="296" width="4" height="142" fill="var(--text-accent)"/>
+  <text x="866" y="319" class="ch">propose</text>
+  <text x="866" y="342" class="cm">/opsx:propose</text>
+  <text x="866" y="356" class="cs">all four artifacts in one shot</text>
+  <text x="866" y="376" class="cm">/opsx:new + /opsx:continue</text>
+  <text x="866" y="390" class="cs">one artifact at a time (reviewable)</text>
+  <text x="866" y="412" class="cb">PR 1 — planning only</text>
+  <text x="866" y="427" class="cs">merged before any code is written</text>
+
+  <rect x="850" y="606" width="252" height="126" rx="8" fill="var(--surface-1)" stroke="var(--border)"/>
+  <rect x="850" y="606" width="4" height="126" fill="var(--text-accent)"/>
+  <text x="866" y="629" class="ch">apply</text>
+  <text x="866" y="652" class="cm">/opsx:apply</text>
+  <text x="866" y="666" class="cs">implement tasks, tick the boxes</text>
+  <text x="866" y="686" class="cm">/opsx:verify</text>
+  <text x="866" y="700" class="cs">code vs spec — reports, never blocks</text>
+  <text x="866" y="722" class="cb">PR 2…n — one per phase, in order</text>
+
+  <rect x="850" y="786" width="252" height="112" rx="8" fill="var(--surface-1)" stroke="var(--border)"/>
+  <rect x="850" y="786" width="4" height="112" fill="var(--text-accent)"/>
+  <text x="866" y="809" class="ch">archive</text>
+  <text x="866" y="832" class="cm">/opsx:archive</text>
+  <text x="866" y="846" class="cs">delta merged into openspec/specs/</text>
+  <text x="866" y="868" class="cb">Final PR — truth changes here</text>
+  <text x="866" y="883" class="cs">close the issue with a pointer</text>
+
+  <ellipse cx="62" cy="930" rx="32" ry="13" class="act"/>
+  <text x="62" y="934" class="lgc">activity</text>
+  <rect x="122" y="917" width="70" height="26" rx="5" class="art"/>
+  <text x="157" y="934" class="lgc">artifact</text>
+  <path d="M216,930 L268,930" class="rd"/>
+  <text x="298" y="934" class="lg">reads</text>
+  <path d="M348,930 L400,930" class="wr"/>
+  <text x="430" y="934" class="lg">writes</text>
+</svg>


### PR DESCRIPTION
Adds a contributor-facing page describing how [OpenSpec](https://github.com/Fission-AI/OpenSpec), GitHub issues, and pull requests fit together, with a diagram of the activities and the artifacts they read and write.

## What this adds

- `tools/etc/docs/development/workflow.adoc` — the page
- `tools/etc/docs/images/openspec-workflow.svg` — the diagram
- `CONTRIBUTING.adoc` — a short pointer at the root, which GitHub surfaces

## Decisions it records

These were previously implicit, or scattered across issue comments:

- **The specification is the contract, and lives in exactly one place at a time** — the change delta while work is in progress, `openspec/specs/` after archive. Neither the issue nor `proposal.md` nor `design.md` is normative.
- **An issue records a pain, not a solution.** It is closed with a pointer to the specification, not a copy of the conclusion, so two documents never claim to be the specification.
- **Planning is merged before implementation begins.** Design is reviewed as markdown, in its own PR, rather than as part of a large code diff.

## Notes for review

- The page is placed under `tools/etc/docs` rather than in a separate tree, so it is published with the rest of the documentation. `index.sh` discovers `.adoc` files by `find | sort`, so it appears automatically as a `development/workflow` tab, positioned right after the `concepts` pages. There is no ordering control today.
- The document sets `:data-uri:` so asciidoctor inlines the SVG. This is deliberate: the standalone page at `docs/development/workflow.html` needs `../images/`, while `docs/index.html` inlines the same content and needs `images/`. Embedding resolves both without changing `gendoc` or `index.sh`.
- The SVG is hand-authored and self-contained, with a `prefers-color-scheme` dark variant. It is not generated from a diagram source. If this diagram is expected to change often, a `[graphviz]` block is the maintainable alternative — `dot` is available in the `asciidoctor/docker-asciidoctor` image the build already uses.
- Rendered locally with `gendoc`'s exact flags to confirm the diagram embeds correctly.

**This documents a proposed process. OpenSpec is not yet initialized in this repository**, so the commands and paths described here do not resolve against anything on `main` today. Merging this is a statement of intent; adopting the tool is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
