### PR TITLE
ci: run the unit tests and the autotest suite on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run unit tests
+        run: make test
+
+      # The autotest suite invokes bin/jq++, a symlink the binary creates for
+      # itself the first time it runs. `make build` links the binary and then
+      # runs it, so this step is what puts bin/jq++ in place: it is a
+      # prerequisite of the suite, not a convenience.
+      - name: Build
+        run: make build
+
+      # The objective check on behaviour. `make test` alone does not exercise
+      # it. Needs jq and diff, both present on the runner image.
+      - name: Run the autotest suite
+        run: tools/bin/autotest

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -17,7 +17,9 @@ context: |
   - tools/etc/autotest/  the end-to-end test suite (see below).
 
   Building and testing
-  - `make build` builds bin/jq++ and runs it.
+  - `make build` builds bin/jqplusplus and runs it; that first run creates
+    the bin/jq++ symlink beside it, which is the path the autotest suite
+    invokes.
   - `make test` runs the Go unit tests (`go test ./...`).
   - `tools/bin/autotest` runs the end-to-end autotest suite. Both must pass;
     `make test` alone does not exercise the suite.


### PR DESCRIPTION
Groundwork before the planning pull request for #91.

## Why

After #93, `.github/workflows/` holds three workflows, and only `openspec-validate.yml` triggers on `pull_request` — `tag-release.yml` and `publish-docs.yml` both trigger on push to `main`. Nothing ran `go test` or `tools/bin/autotest` before a merge.

That leaves the mechanical check on planning artifacts enforced and the objective check on behaviour unenforced, which is backwards from where the risk sits in the work ahead. `openspec/config.yaml` already says of the autotest suite: "This suite is the objective check on behaviour. A change to evaluation semantics should add or amend cases here." The first implementation phase of #91 is expected to encode the agreed semantics as autotest cases before the engine is touched, so those cases need something that runs them.

## What changes

`.github/workflows/test.yml`, triggered on `pull_request` to match `openspec-validate.yml`:

1. `make test` — the Go unit tests.
2. `make build` — required before the suite, see below.
3. `tools/bin/autotest` — the end-to-end suite.

Go comes from `go-version-file: go.mod`, the same way `tag-release.yml` resolves it. `jq` and `diff`, which `tools/bin/_autotest.sh` shells out to, are present on the runner image.

The build step is a prerequisite rather than a convenience: `tools/bin/autotest` invokes `bin/jq++`, which is a symlink the binary creates for itself on its first run (`cmd/jqplusplus/main.go:206`), and `make build` links `bin/jqplusplus` and then runs it. Without the build step the suite has no binary to invoke. The workflow says so in a comment, so the ordering is not silently load-bearing.

## Also

`openspec/config.yaml` described `make build` as building `bin/jq++`. The Makefile sets `BINARY_NAME=jqplusplus`, so the build output is `bin/jqplusplus` and `bin/jq++` is the symlink that appears beside it. Corrected, and the symlink's role spelled out, since that file is the project context every `/opsx:*` command reads.

## Verification

Ran the workflow's step sequence locally from a clean tree (`make clean`), in order:

- `make test` — pass
- `make build` — pass, and `bin/jq++` appears
- `tools/bin/autotest` — `No test failed (total=155; passed=155; skipped=0)`

Also confirmed both YAML files parse, and that `openspec validate --all --strict` still exits 0 after the `config.yaml` edit.

Separately, while checking the gate added in #93: it currently reports `No items found to validate` and exits 0 on the empty `openspec/`, so it does not block pull requests today; and against a probe change carrying a requirement with no scenario it exits 1. The `--all` flag is doing its job in both directions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvVdjZgajuXSFH2THNxQS4)_