### PR TITLE
feat: compose arrays on inheritance with the $super splice marker

### DIFF
--- a/internal/inheritance.go
+++ b/internal/inheritance.go
@@ -21,7 +21,14 @@ func LoadAndResolveInheritances(baseDir string, filename string, searchPaths []s
 		}
 	}()
 
-	return NewNodePoolWithBaseSearchPaths(baseDir, sessionDirectory, searchPaths).ReadNodeEntryValue(baseDir, filename, []*JqModule{})
+	nodeEntryValue, err := NewNodePoolWithBaseSearchPaths(baseDir, sessionDirectory, searchPaths).ReadNodeEntryValue(baseDir, filename, []*JqModule{})
+	if err != nil {
+		return nil, err
+	}
+	if err := GroundMarkers(nodeEntryValue.Obj); err != nil {
+		return nil, err
+	}
+	return nodeEntryValue, nil
 }
 
 // LoadAndResolveInheritancesRecursively loads a JSON file, resolves $extends or $includes recursively, and merges parents.
@@ -164,14 +171,20 @@ func resolveInheritances(obj map[string]any, compilerOptions []*JqModule, nodepo
 			if i == 0 {
 				mergedParents = nodeEntryValue.Obj
 			} else {
-				mergedParents = mergeObjects(mergedParents, nodeEntryValue.Obj)
+				mergedParents, err = mergeObjects(mergedParents, nodeEntryValue.Obj)
+				if err != nil {
+					return nil, fmt.Errorf("%v: parent: %v", err, parent)
+				}
 			}
 			tmpCompilerOptions = append(tmpCompilerOptions, nodeEntryValue.CompilerOptions...)
 		}
 		if !mergeType.IsOrderReversed() {
-			obj = mergeObjects(mergedParents, obj)
+			obj, err = mergeObjects(mergedParents, obj)
 		} else {
-			obj = mergeObjects(obj, mergedParents)
+			obj, err = mergeObjects(obj, mergedParents)
+		}
+		if err != nil {
+			return nil, err
 		}
 		delete(obj, mergeType.String())
 	}

--- a/internal/json.go
+++ b/internal/json.go
@@ -208,11 +208,22 @@ func valueToAny(v hocon.Value) any {
 }
 
 // mergeObjects merges parent and child objects, with child values taking precedence.
-func mergeObjects(parent, child map[string]any) map[string]any {
+func mergeObjects(parent, child map[string]any) (map[string]any, error) {
 	return MergeObjects(parent, child, MergePolicyDefault)
 }
 
-func MergeObjects(a, b map[string]interface{}, policy MergePolicy) map[string]interface{} {
+func MergeObjects(a, b map[string]interface{}, policy MergePolicy) (map[string]interface{}, error) {
+	return mergeObjectsAt(a, b, policy, nil)
+}
+
+func mergeObjectsAt(a, b map[string]interface{}, policy MergePolicy, path []any) (map[string]interface{}, error) {
+	// childPath copies rather than appending in place: sibling keys would
+	// otherwise share a backing array and overwrite each other's last segment.
+	childPath := func(k string) []any {
+		p := make([]any, len(path), len(path)+1)
+		copy(p, path)
+		return append(p, k)
+	}
 	result := make(map[string]interface{})
 	for k, v := range a {
 		result[k] = v
@@ -220,13 +231,92 @@ func MergeObjects(a, b map[string]interface{}, policy MergePolicy) map[string]in
 	for k, v := range b {
 		if av, ok := result[k].(map[string]interface{}); ok {
 			if bv, ok := v.(map[string]interface{}); ok {
-				result[k] = MergeObjects(av, bv, policy)
+				merged, err := mergeObjectsAt(av, bv, policy, childPath(k))
+				if err != nil {
+					return nil, err
+				}
+				result[k] = merged
 				continue
 			}
 		}
+		if child, ok := v.([]any); ok {
+			inherited, present := result[k]
+			composed, err := composeArrayAt(inherited, present, child, childPath(k))
+			if err != nil {
+				return nil, err
+			}
+			result[k] = composed
+			continue
+		}
 		result[k] = v
 	}
-	return result
+	return result, nil
+}
+
+// composeArrayAt composes a child array with the array it inherits. An unmarked
+// array replaces, exactly as it always has. A marked array is a delta: it
+// carries unchanged while the inherited array is absent, and resolves against
+// it once one is present.
+func composeArrayAt(inherited any, present bool, child []any, path []any) (any, error) {
+	kind, at, err := scanArrayMarkers(child)
+	if err != nil {
+		return nil, fmt.Errorf("%v: at '%s'", err, toPathExpression(path))
+	}
+	if !kind.IsMarker() {
+		return child, nil
+	}
+	if !present {
+		// Nothing to bind to yet. The delta carries, which is what lets a
+		// fragment resolved on its own contribute to a document that includes
+		// it later.
+		return child, nil
+	}
+	inheritedArray, ok := inherited.([]any)
+	if !ok {
+		return nil, fmt.Errorf("array composition marker requires an inherited array, but got %T: at '%s'", inherited, toPathExpression(path))
+	}
+	switch kind {
+	case SpliceMarker:
+		return spliceArray(inheritedArray, child, at), nil
+	default:
+		// MarkerPair is not implemented yet; it carries and is reported by
+		// grounding until pairing lands.
+		return child, nil
+	}
+}
+
+// spliceArray substitutes the inherited elements at the marker's position,
+// building a fresh slice: the node pool shares backing arrays between every
+// document that inherits a file, so appending into one would corrupt them all.
+//
+// Inherited elements are copied verbatim, markers included. That is what makes
+// two splice deltas compose into a third, still-pending delta.
+func spliceArray(inherited []any, child []any, at int) []any {
+	out := make([]any, 0, len(child)-1+len(inherited))
+	out = append(out, child[:at]...)
+	out = append(out, inherited...)
+	out = append(out, child[at+1:]...)
+	return out
+}
+
+// scanArrayMarkers finds the array's marker, rejecting an undefined spelling in
+// the reserved namespace and an array carrying more than one marker.
+func scanArrayMarkers(arr []any) (MarkerKind, int, error) {
+	kind, at := NotAMarker, -1
+	for i, e := range arr {
+		k, err := ClassifyMarkerElement(e)
+		if err != nil {
+			return NotAMarker, -1, err
+		}
+		if !k.IsMarker() {
+			continue
+		}
+		if at >= 0 {
+			return NotAMarker, -1, fmt.Errorf("more than one array composition marker: %v", arr)
+		}
+		kind, at = k, i
+	}
+	return kind, at, nil
 }
 
 // MergePolicy defines the policy for merging objects.

--- a/internal/json_test.go
+++ b/internal/json_test.go
@@ -96,7 +96,10 @@ func TestMergeObjects_DeepMerge(t *testing.T) {
 		},
 		"c": 3,
 	}
-	result := mergeObjects(parent, child)
+	result, err := mergeObjects(parent, child)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("expected %v, got %v", expected, result)
 	}
@@ -107,7 +110,10 @@ func TestMergeObjects(t *testing.T) {
 		a := map[string]interface{}{"a": 1, "b": 2}
 		b := map[string]interface{}{"b": 3, "c": 4}
 		expected := map[string]interface{}{"a": 1, "b": 3, "c": 4}
-		result := MergeObjects(a, b, MergePolicyDefault)
+		result, err := MergeObjects(a, b, MergePolicyDefault)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if !reflect.DeepEqual(result, expected) {
 			t.Errorf("expected %v, got %v", expected, result)
 		}
@@ -127,7 +133,10 @@ func TestMergeObjects(t *testing.T) {
 			"b": map[string]interface{}{"x": 10, "y": 200, "z": 300},
 			"c": 3,
 		}
-		result := MergeObjects(a, b, MergePolicyDefault)
+		result, err := MergeObjects(a, b, MergePolicyDefault)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if !reflect.DeepEqual(result, expected) {
 			t.Errorf("expected %v, got %v", expected, result)
 		}
@@ -137,7 +146,10 @@ func TestMergeObjects(t *testing.T) {
 		a := map[string]interface{}{"a": 1, "b": 2}
 		b := map[string]interface{}{"b": 100}
 		expected := map[string]interface{}{"a": 1, "b": 100}
-		result := MergeObjects(a, b, MergePolicyDefault)
+		result, err := MergeObjects(a, b, MergePolicyDefault)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if !reflect.DeepEqual(result, expected) {
 			t.Errorf("expected %v, got %v", expected, result)
 		}
@@ -147,7 +159,10 @@ func TestMergeObjects(t *testing.T) {
 		a := map[string]interface{}{}
 		b := map[string]interface{}{"a": 1}
 		expected := map[string]interface{}{"a": 1}
-		result := MergeObjects(a, b, MergePolicyDefault)
+		result, err := MergeObjects(a, b, MergePolicyDefault)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if !reflect.DeepEqual(result, expected) {
 			t.Errorf("expected %v, got %v", expected, result)
 		}
@@ -155,7 +170,10 @@ func TestMergeObjects(t *testing.T) {
 		a2 := map[string]interface{}{"a": 1}
 		b2 := map[string]interface{}{}
 		expected2 := map[string]interface{}{"a": 1}
-		result2 := MergeObjects(a2, b2, MergePolicyDefault)
+		result2, err := MergeObjects(a2, b2, MergePolicyDefault)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if !reflect.DeepEqual(result2, expected2) {
 			t.Errorf("expected %v, got %v", expected2, result2)
 		}

--- a/internal/markers.go
+++ b/internal/markers.go
@@ -1,0 +1,152 @@
+package internal
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Array composition markers. A marker is one of these exact strings written as
+// a direct element of an array value, telling the inheritance stage how that
+// array composes with the array it inherits.
+const (
+	// MarkerSplice substitutes the inherited array's elements at its position.
+	MarkerSplice = "$super"
+	// MarkerPair ends the literal prefix and begins index-wise pairing with the
+	// inherited elements.
+	MarkerPair = "$super*"
+)
+
+// markerNamespace is reserved: a string starting with it, followed by a
+// character that cannot appear in an identifier, must be a defined marker or it
+// is an error. That keeps undefined spellings such as "$super[1:]" available to
+// gain meaning later without changing any working configuration.
+const markerNamespace = "$super"
+
+// MarkerKind classifies a string found in a direct array element position.
+type MarkerKind int
+
+const (
+	// NotAMarker is ordinary data.
+	NotAMarker MarkerKind = iota
+	// SpliceMarker is MarkerSplice.
+	SpliceMarker
+	// PairMarker is MarkerPair.
+	PairMarker
+)
+
+func (k MarkerKind) String() string {
+	switch k {
+	case SpliceMarker:
+		return MarkerSplice
+	case PairMarker:
+		return MarkerPair
+	default:
+		return "not a marker"
+	}
+}
+
+// IsMarker reports whether the kind denotes a marker rather than ordinary data.
+func (k MarkerKind) IsMarker() bool {
+	return k == SpliceMarker || k == PairMarker
+}
+
+// ClassifyMarker classifies a string in a direct array element position.
+//
+// A string equal to a defined marker is that marker. A string beginning with
+// the reserved namespace followed by an identifier character is a different
+// word, and so is ordinary data: "$supervisor" is not a malformed "$super".
+// A string beginning with the namespace followed by anything else is an
+// undefined spelling within it, and is an error.
+func ClassifyMarker(s string) (MarkerKind, error) {
+	switch s {
+	case MarkerSplice:
+		return SpliceMarker, nil
+	case MarkerPair:
+		return PairMarker, nil
+	}
+	if !strings.HasPrefix(s, markerNamespace) {
+		return NotAMarker, nil
+	}
+	r, _ := utf8.DecodeRuneInString(s[len(markerNamespace):])
+	if isIdentifierRune(r) {
+		return NotAMarker, nil
+	}
+	return NotAMarker, fmt.Errorf("unknown array composition marker: %q; expected %q or %q", s, MarkerSplice, MarkerPair)
+}
+
+// ClassifyMarkerElement classifies an array element, which is a marker only if
+// it is a string.
+func ClassifyMarkerElement(v any) (MarkerKind, error) {
+	s, ok := v.(string)
+	if !ok {
+		return NotAMarker, nil
+	}
+	return ClassifyMarker(s)
+}
+
+func isIdentifierRune(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// GroundMarkers reports any array composition marker that composition never
+// resolved. It is the final pass over the top-level object, after node-level
+// inheritance and before key-side evaluation.
+//
+// A marker still present at this point can never be bound to anything, so
+// reporting it surfaces mistakes that a silent empty splice would hide: a
+// mistyped key, a forgotten $extends, or a parent skipped by the optional-file
+// marker. It also catches a marker written where nothing could ever bind it —
+// inside an array nested in an unmarked array, or inside a value that pairing
+// took whole.
+//
+// This runs on the top-level object only. Per-file cached resolutions keep
+// their markers, because a fragment's delta is meant to survive until the
+// document that includes it supplies an array to bind against.
+//
+// Strings produced by eval: expressions are not seen here, since value-side
+// evaluation has not run yet. Marker classification is a check on what the
+// author wrote, not on what the document renders.
+func GroundMarkers(v any) error {
+	return groundMarkers(v, nil)
+}
+
+func groundMarkers(v any, path []any) error {
+	switch t := v.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if err := groundMarkers(t[k], appendPathSegment(path, k)); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for i, e := range t {
+			kind, err := ClassifyMarkerElement(e)
+			if err != nil {
+				return fmt.Errorf("%v: at '%s'", err, toPathExpression(path))
+			}
+			if kind.IsMarker() {
+				return fmt.Errorf("unresolved array composition marker: %q: at '%s'", kind.String(), toPathExpression(path))
+			}
+			if err := groundMarkers(e, appendPathSegment(path, i)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// appendPathSegment copies rather than appending in place, so that siblings do
+// not share a backing array and overwrite each other's last segment.
+func appendPathSegment(path []any, segment any) []any {
+	p := make([]any, len(path), len(path)+1)
+	copy(p, path)
+	return append(p, segment)
+}

--- a/internal/markers_test.go
+++ b/internal/markers_test.go
@@ -1,0 +1,87 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClassifyMarker(t *testing.T) {
+	t.Run("defined markers", func(t *testing.T) {
+		for _, c := range []struct {
+			in   string
+			want MarkerKind
+		}{
+			{"$super", SpliceMarker},
+			{"$super*", PairMarker},
+		} {
+			got, err := ClassifyMarker(c.in)
+			if err != nil {
+				t.Errorf("%q: unexpected error: %v", c.in, err)
+			}
+			if got != c.want {
+				t.Errorf("%q: expected %v, got %v", c.in, c.want, got)
+			}
+			if !got.IsMarker() {
+				t.Errorf("%q: expected a marker", c.in)
+			}
+		}
+	})
+
+	t.Run("undefined spellings in the namespace are errors", func(t *testing.T) {
+		for _, in := range []string{"$super[1:]", "$super?", "$super*?", "$super**", "$super("} {
+			got, err := ClassifyMarker(in)
+			if err == nil {
+				t.Errorf("%q: expected an error, got %v", in, got)
+				continue
+			}
+			if !strings.Contains(err.Error(), "unknown array composition marker") {
+				t.Errorf("%q: unexpected message: %v", in, err)
+			}
+		}
+	})
+
+	t.Run("an identifier continuation is a different word", func(t *testing.T) {
+		for _, in := range []string{"$supervisor", "$super_home", "$super1", "$superuser"} {
+			got, err := ClassifyMarker(in)
+			if err != nil {
+				t.Errorf("%q: unexpected error: %v", in, err)
+			}
+			if got != NotAMarker {
+				t.Errorf("%q: expected ordinary data, got %v", in, got)
+			}
+		}
+	})
+
+	t.Run("ordinary strings", func(t *testing.T) {
+		for _, in := range []string{"", "super", "$sup", "a", "raw:$super", "eval:string:1"} {
+			got, err := ClassifyMarker(in)
+			if err != nil {
+				t.Errorf("%q: unexpected error: %v", in, err)
+			}
+			if got != NotAMarker {
+				t.Errorf("%q: expected ordinary data, got %v", in, got)
+			}
+		}
+	})
+}
+
+func TestClassifyMarkerElement(t *testing.T) {
+	t.Run("non-strings are never markers", func(t *testing.T) {
+		for _, in := range []any{1, true, nil, []any{"$super"}, map[string]any{"$super": 1}} {
+			got, err := ClassifyMarkerElement(in)
+			if err != nil {
+				t.Errorf("%v: unexpected error: %v", in, err)
+			}
+			if got != NotAMarker {
+				t.Errorf("%v: expected ordinary data, got %v", in, got)
+			}
+		}
+	})
+
+	t.Run("strings are classified", func(t *testing.T) {
+		got, err := ClassifyMarkerElement("$super")
+		if err != nil || got != SpliceMarker {
+			t.Errorf("expected the splice marker, got %v (%v)", got, err)
+		}
+	})
+}


### PR DESCRIPTION
**Stack 1 of 3** for #91 phase 1 — the engine change on its own.

| | PR | Base |
|---|---|---|
| **1** | **this** — engine | `main` |
| 2 | autotest coverage | this |
| 3 | OpenSpec artifacts | 2 |

## The change in one line

Arrays were replaced on inheritance not by decision but by omission: `MergeObjects` recursed when both sides were objects and let everything else fall through to child-replaces. This adds composition at that same seam.

## What is here

- **`internal/markers.go`** classifies a string in direct array element position. A defined marker is a marker; `$super` followed by an identifier character is a different word and stays data (`$supervisor`); `$super` followed by anything else is an undefined spelling in the reserved namespace and is an error — which keeps `$super[1:]` and `$super?` available to gain meaning later.
- **`MergeObjects`** composes a marked array against the array it inherits. **It now returns an error**, so `mergeObjects` and `resolveInheritances` thread one. That is the API change worth a look.
- **Splicing builds a fresh slice.** The node pool shares backing arrays between every document that inherits a file, so appending into one would corrupt them all.
- **Inherited elements are copied verbatim, markers included**, so two splice deltas compose into a third that is still pending — the property the associativity requirement rests on.
- **A marked array carries while the inherited array is absent**, which is what lets an `$includes` fragment contribute to a document it knows nothing about.
- **`GroundMarkers`** walks the top-level object after composition and reports any marker that never resolved. It runs before value-side evaluation, so an `eval:`-produced string is never classified as a marker.

## Tests here

Unit tests for marker classification. **Behavioural coverage is deliberately in PR 2**, so this one reviews as engine and that one as evidence.

This branch stands on its own: `go test ./...` passes and the pre-existing autotest suite is **155/155**, which is the regression check that plain replacement still behaves.

## Intermediate state, deliberate

`$super*` is reported as an unresolved marker rather than pairing until phase 2. It errors instead of silently mis-composing, but the spec delta is not satisfied for that marker yet.

Replaces #97, which carried all three parts as one commit.
